### PR TITLE
Implement V6 Claude Code terminal UI across the site

### DIFF
--- a/assets/css/extended/personal-home.css
+++ b/assets/css/extended/personal-home.css
@@ -1,575 +1,1312 @@
-@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap');
+/* =======================================================================
+   V6 "Agent" — Claude Code-style terminal UI for Leonardo's site.
+   Site-wide dark theme. Design source: Claude Design handoff (2026-04).
+   ======================================================================= */
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap');
 
 :root {
-  --personal-page-top: #f4f7fb;
-  --personal-page-bottom: #f4f7fb;
-  --personal-page-surface: #f4f7fb;
-  --personal-bg: #f5f7fb;
-  --personal-card: #ffffff;
-  --personal-text: #0f172a;
-  --personal-muted: #475569;
-  --personal-accent: #0f766e;
-  --personal-accent-soft: #14b8a6;
-  --personal-border: #d6dde8;
-  --personal-shadow: 0 10px 28px -22px rgba(15, 23, 42, 0.34);
-  --personal-shadow-hover: 0 16px 26px -22px rgba(15, 23, 42, 0.26);
-  --personal-hero-border: color-mix(in oklab, var(--personal-accent), #ffffff 74%);
-  --personal-identity-border: #c5d9f0;
-  --personal-identity-text: #0f3a5a;
-  --personal-identity-bg: #edf2fb;
-  --personal-btn-secondary-bg: #ffffff;
-  --personal-btn-secondary-border: #a8bbce;
-  --personal-btn-ghost-border: #b7cae4;
-  --personal-now-border: #d3dde9;
-  --personal-now-bg: #f8fbff;
-  --personal-focus-border: #c9d8e8;
-  --personal-focus-bg: #fbfdff;
-  --personal-focus-text: #1e293b;
-  --personal-skill-bg: #edf2f9;
-  --personal-skill-text: #113f72;
-  --personal-card-border: #dde5f0;
-  --personal-card-border-hover: #8ec6bf;
-  --personal-card-shadow: 0 10px 24px -20px rgba(15, 23, 42, 0.12);
-  --personal-meta: #64748b;
-  --personal-meta-list-border: #d7e0ef;
-  --personal-meta-list-text: #0f4c81;
-  --personal-link: #0f766e;
-  --personal-section-bg: color-mix(in oklab, #ffffff 92%, var(--personal-page-surface));
-  --personal-section-border: #d6dde8;
-  --personal-section-shadow: 0 12px 30px -24px rgba(15, 23, 42, 0.22);
+  --paper:     #1f1e1d;
+  --paper-2:   #262624;
+  --paper-top: #2b2a28;
+  --paper-low: #1a1918;
+  --paper-in:  #222120;
+
+  --ink:   #F5F4EE;
+  --ink-2: #E8E6DF;
+  --ink-3: #B1AEA4;
+  --ink-4: #8F8B80;
+  --ink-5: #6B6862;
+  --ink-6: #4F4D47;
+  --ink-7: #3A3936;
+
+  --accent:      #D97757;
+  --accent-hi:   #E88968;
+  --accent-soft: rgba(217, 119, 87, 0.08);
+  --accent-soft-2: rgba(217, 119, 87, 0.04);
+  --accent-line: rgba(217, 119, 87, 0.20);
+  --accent-line-2: rgba(217, 119, 87, 0.25);
+
+  --rule:        rgba(245, 244, 238, 0.10);
+  --rule-soft:   rgba(245, 244, 238, 0.06);
+  --rule-mid:    rgba(245, 244, 238, 0.08);
+  --rule-dashed: rgba(245, 244, 238, 0.12);
+  --rule-strong: rgba(245, 244, 238, 0.20);
+
+  --ok:   #7BAE72;
+  --warn: #C4A155;
+  --err:  #C4554D;
+
+  --mono:  'IBM Plex Mono', ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  --sans:  'IBM Plex Sans', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --serif: 'Instrument Serif', 'Iowan Old Style', Georgia, serif;
+
+  --shell-max: 1100px;
 }
 
-.dark {
-  --personal-page-top: #0b1220;
-  --personal-page-bottom: #0b1220;
-  --personal-page-surface: #0b1220;
-  --personal-bg: #0f172a;
-  --personal-card: #111b2e;
-  --personal-text: #e5e7eb;
-  --personal-muted: #9ca3af;
-  --personal-accent: #2dd4bf;
-  --personal-accent-soft: #5eead4;
-  --personal-border: #233344;
-  --personal-shadow: 0 12px 30px -26px rgba(0, 0, 0, 0.58);
-  --personal-shadow-hover: 0 18px 30px -24px rgba(0, 0, 0, 0.72);
-  --personal-hero-border: color-mix(in oklab, var(--personal-accent), #ffffff 86%);
-  --personal-identity-border: #1e3a4f;
-  --personal-identity-text: #a3d9f8;
-  --personal-identity-bg: #122336;
-  --personal-btn-secondary-bg: #111b2e;
-  --personal-btn-secondary-border: #2e4e65;
-  --personal-btn-ghost-border: #33566f;
-  --personal-now-border: #1d3448;
-  --personal-now-bg: #13223a;
-  --personal-focus-border: #2c4358;
-  --personal-focus-bg: #12263d;
-  --personal-focus-text: #cbd9e7;
-  --personal-skill-bg: #132435;
-  --personal-skill-text: #9fd4ff;
-  --personal-card-border: #253a50;
-  --personal-card-border-hover: #4d6f8b;
-  --personal-card-shadow: 0 10px 24px -22px rgba(0, 0, 0, 0.66);
-  --personal-meta: #90a1b5;
-  --personal-meta-list-border: #2b3f57;
-  --personal-meta-list-text: #95b9ff;
-  --personal-link: #2dd4bf;
-  --personal-section-bg: color-mix(in oklab, #132238 86%, #0b1220);
-  --personal-section-border: #203449;
-  --personal-section-shadow: 0 14px 28px -22px rgba(0, 0, 0, 0.52);
+/* Force dark agent aesthetic regardless of theme toggle */
+html, body,
+body.dark,
+body:not(.dark) {
+  background: var(--paper) !important;
+  color: var(--ink) !important;
+  font-family: var(--mono) !important;
+  font-size: 13.5px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
 }
 
-.list,
-body.list {
-  background: linear-gradient(180deg, var(--personal-page-top), var(--personal-page-bottom));
-  background-color: var(--personal-page-surface);
+body {
+  position: relative;
+  overflow-x: hidden;
 }
 
-body,
-html {
-  background-color: var(--personal-page-surface);
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(1200px 600px at 30% -10%, rgba(217, 119, 87, 0.08), transparent 60%),
+    radial-gradient(800px 500px at 85% 110%, rgba(217, 119, 87, 0.05), transparent 60%);
 }
 
-main.main,
-.list .main,
-body.list .main {
-  background: transparent !important;
+.main, main, #main {
+  position: relative;
+  z-index: 1;
+  max-width: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
 }
 
-.header {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  background: color-mix(in oklab, var(--personal-card) 88%, transparent);
-  border-bottom: 1px solid var(--personal-border);
-  backdrop-filter: blur(10px);
+::selection { background: var(--accent); color: var(--paper); }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-hi); }
+
+kbd {
+  background: rgba(245, 244, 238, 0.08);
+  border: 1px solid var(--rule-dashed);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--ink-3);
 }
 
-.nav {
-  max-width: min(1080px, 92vw);
-  margin-inline-start: auto;
-  margin-inline-end: auto;
-}
+/* -----------------------------------------------------------------------
+   Top bar (replaces PaperMod .header)
+   ----------------------------------------------------------------------- */
+body > header.header { display: none !important; }
 
-.logo a {
-  color: var(--personal-text);
+.v6-topbar-wrap {
+  position: relative;
+  z-index: 2;
+  padding: 18px 24px 0;
 }
-
-.logo-switches {
-  gap: 0.25rem;
-}
-
-#menu a {
-  font-size: 0.98rem;
-  display: inline-flex;
-}
-
-#menu a span {
-  color: var(--personal-text);
-  border-radius: 0.45rem;
-  padding: 0.2rem 0.3rem;
-  border: 0;
-  transition: color 140ms ease;
-}
-
-#menu a span:hover {
-  color: var(--personal-accent);
-}
-
-#menu .active,
-#menu .active:hover {
-  color: var(--personal-accent);
-  font-weight: 700;
-  border-radius: 0.45rem;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-.home-section-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-  margin-top: 0.95rem;
-}
-
-.home-section-nav-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.42rem 0.8rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 700;
-  border: 1px solid var(--personal-btn-secondary-border);
-  color: var(--personal-text);
-  text-decoration: none;
-  transition: transform 140ms ease, background-color 140ms ease, color 140ms ease, border-color 140ms ease;
-}
-
-.home-section-nav-link:hover {
-  color: var(--personal-accent);
-  border-color: var(--personal-accent);
-  transform: translateY(-1px);
-}
-
-.home-wrap {
-  width: min(1080px, 100%);
+.v6-topbar {
+  max-width: var(--shell-max);
   margin: 0 auto;
-  padding: clamp(1rem, 2.6vw, 2rem) clamp(0.35rem, 1.4vw, 0.9rem);
-  display: grid;
-  gap: 1.35rem;
-  align-content: start;
-  justify-items: stretch;
-}
-
-.home-hero,
-.home-section {
-  width: 100%;
-  padding: clamp(1rem, 2.4vw, 1.6rem);
-  border: 1px solid var(--personal-section-border);
-  border-radius: 1rem;
-  background: var(--personal-section-bg);
-  box-shadow: var(--personal-section-shadow);
-}
-
-.home-hero {
-  border-color: var(--personal-hero-border);
-}
-
-.home-section {
-  padding-bottom: clamp(1rem, 2.2vw, 1.35rem);
-}
-
-.home-kicker {
-  font: 600 0.75rem/1.3 "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--personal-accent);
-  margin: 0 0 0.5rem;
-}
-
-.home-title {
-  margin: 0;
-  color: var(--personal-text);
-  font: 800 clamp(2rem, 4vw, 2.8rem) / 1.12 "Manrope", "Noto Sans TC", system-ui, -apple-system, sans-serif;
-}
-
-.home-subtitle,
-.home-intro,
-.home-about-content,
-.home-now p {
-  color: var(--personal-muted);
-  font-size: clamp(0.98rem, 1.9vw, 1.07rem);
-  line-height: 1.7;
-  margin: 0.75rem 0;
-  max-width: 70ch;
-}
-
-.home-identity-wrap {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  margin: 0.85rem 0 0;
-}
-
-.home-identity {
-  display: inline-flex;
-  border-radius: 999px;
-  border: 1px solid var(--personal-identity-border);
-  padding: 0.34rem 0.76rem;
-  font-size: 0.78rem;
-  font-weight: 700;
-  color: var(--personal-identity-text);
-  background: var(--personal-identity-bg);
-}
-
-.home-cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  margin-top: 1rem;
-  align-items: center;
-}
-
-.home-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.62rem 1rem;
-  border-radius: 999px;
-  font-weight: 700;
-  text-decoration: none;
-  border: 1px solid transparent;
-  transition: transform 140ms ease, background-color 140ms ease, color 140ms ease, border-color 140ms ease;
-}
-
-.home-btn:hover {
-  transform: translateY(-1px);
-}
-
-.home-btn-primary {
-  background: var(--personal-accent);
-  color: #ffffff;
-  border-color: var(--personal-accent);
-}
-
-.home-btn-primary:hover {
-  background: #115e59;
-  border-color: #115e59;
-}
-
-.home-btn-secondary,
-.home-btn-ghost {
-  color: var(--personal-text);
-  background: var(--personal-btn-secondary-bg);
-}
-
-.home-btn-secondary {
-  border-color: var(--personal-btn-secondary-border);
-}
-
-.home-btn-secondary:hover {
-  border-color: var(--personal-accent);
-  color: var(--personal-accent);
-}
-
-.home-btn-ghost {
-  border-style: dashed;
-  border-color: var(--personal-btn-ghost-border);
-}
-
-.home-btn-ghost:hover {
-  border-color: var(--personal-accent-soft);
-  color: var(--personal-accent);
-}
-
-.home-now {
-  margin-top: 1.05rem;
-  border: 1px solid var(--personal-now-border);
-  background: var(--personal-now-bg);
-  padding: 0.8rem 1rem;
-  border-radius: 0.75rem;
-}
-
-.home-now-label {
-  margin: 0 0 0.3rem;
-  font: 700 0.78rem "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--personal-accent);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.home-now p {
-  margin: 0;
-  color: var(--personal-text);
-  max-width: none;
-}
-
-.home-focus-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-  gap: 0.58rem;
-  margin-top: 0.85rem;
-}
-
-.home-focus-item {
-  margin: 0;
-  border: 1px dashed var(--personal-focus-border);
-  border-radius: 0.7rem;
-  padding: 0.62rem 0.75rem;
-  color: var(--personal-focus-text);
-  background: var(--personal-focus-bg);
-  font-size: 0.88rem;
-}
-
-.home-skill-title {
-  margin: 1rem 0 0.6rem;
-  color: var(--personal-muted);
-  font-size: 0.87rem;
-  font-weight: 700;
-}
-
-.home-skill-wrap {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.home-skill {
-  display: inline-flex;
-  border-radius: 999px;
-  padding: 0.34rem 0.72rem;
-  font-size: 0.82rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  background: var(--personal-skill-bg);
-  color: var(--personal-skill-text);
-}
-
-.home-section-head {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  gap: 0.75rem;
-  margin-bottom: 0.95rem;
+  align-items: center;
+  padding: 8px 2px 16px;
+  border-bottom: 1px dashed var(--rule-dashed);
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-4);
 }
-
-.home-section h2 {
-  margin: 0;
-  font-size: clamp(1.25rem, 2.4vw, 1.55rem);
-  font-weight: 800;
-  color: var(--personal-text);
-}
-
-.home-link {
-  color: var(--personal-link);
-  font-weight: 700;
+.v6-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink);
   text-decoration: none;
 }
+.v6-brand:hover { color: var(--ink); }
+.v6-brand-glyph {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background: var(--accent);
+  color: var(--paper);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+.v6-brand b { font-weight: 500; letter-spacing: 0.02em; }
+.v6-brand span { color: var(--ink-4); margin-left: 6px; font-weight: 400; }
 
-.home-link:hover {
-  text-decoration: underline;
+.v6-topnav { display: flex; gap: 18px; list-style: none; margin: 0; padding: 0; }
+.v6-topnav a {
+  color: var(--ink-4);
+  text-decoration: none;
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+  transition: color 0.12s, border-color 0.12s;
+}
+.v6-topnav a:hover { color: var(--accent); }
+.v6-topnav a.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
-.home-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.95rem;
+.v6-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink-4);
+}
+.v6-status i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ok);
+  box-shadow: 0 0 8px rgba(123, 174, 114, 0.5);
+  display: inline-block;
 }
 
-.home-card {
-  padding: 0.95rem;
-  border-radius: 0.85rem;
-  border: 1px solid var(--personal-card-border);
-  background: var(--personal-card);
+/* -----------------------------------------------------------------------
+   Shell + Panel (shared terminal card)
+   ----------------------------------------------------------------------- */
+.v6-shell {
+  position: relative;
+  z-index: 1;
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 20px 24px 32px;
+}
+
+.v6-panel {
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
-  gap: 0.56rem;
-  min-height: 100%;
+}
+.v6-panel-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--rule-mid);
+  background: linear-gradient(to bottom, var(--paper-top), var(--paper-2));
+}
+.v6-panel-top-l {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+.v6-dots { display: flex; gap: 6px; }
+.v6-dots i { width: 10px; height: 10px; border-radius: 50%; display: block; }
+.v6-dots i.r { background: var(--err); }
+.v6-dots i.y { background: var(--warn); }
+.v6-dots i.g { background: var(--ok); }
+.v6-panel-top-r {
+  color: var(--ink-4);
+  font-size: 11px;
+  display: flex;
+  gap: 14px;
+}
+.v6-panel-top-r span::before {
+  content: "·";
+  margin-right: 10px;
+  color: var(--ink-6);
+}
+.v6-panel-top-r span:first-child::before { content: ""; margin: 0; }
+
+/* -----------------------------------------------------------------------
+   Home / Agent conversation
+   ----------------------------------------------------------------------- */
+.v6-convo {
+  padding: 22px 28px 28px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 540px;
+}
+.v6-welcome {
+  border: 1px solid var(--accent-line-2);
+  background: linear-gradient(to bottom right, rgba(217,119,87,0.07), rgba(217,119,87,0.02));
+  border-radius: 10px;
+  padding: 18px 22px;
+  margin-bottom: 26px;
+}
+.v6-welcome-title {
+  font-family: var(--serif);
+  font-size: 26px;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  font-weight: 400;
+}
+.v6-welcome-title em { color: var(--accent); font-style: italic; }
+.v6-welcome p {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.v6-welcome-hint {
+  margin-top: 14px;
+  font-size: 11px;
+  color: var(--ink-5);
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.v6-msg { margin: 18px 0; }
+.v6-msg-user { display: flex; gap: 12px; align-items: flex-start; }
+.v6-prompt {
+  color: var(--accent);
+  font-weight: 500;
+  user-select: none;
+  padding-top: 1px;
+}
+.v6-msg-user-text { color: var(--ink); flex: 1; }
+
+.v6-msg-system {
+  color: var(--ink-5);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding-left: 22px;
+}
+.v6-msg-system::before { content: "✓ "; color: var(--ok); }
+
+.v6-msg-assistant { padding-left: 22px; margin-top: 12px; }
+
+.v6-tools {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.v6-tool {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 4px 8px;
+  background: rgba(245, 244, 238, 0.05);
+  border: 1px solid var(--rule-dashed);
+  border-radius: 6px;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+.v6-tool .ok {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(120, 176, 106, 0.18);
+  color: var(--ok);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+}
+.v6-tool b { color: var(--ink); font-weight: 500; }
+.v6-tool em { color: var(--accent); font-style: normal; }
+
+.v6-md p {
+  margin: 0 0 12px;
+  color: var(--ink-2);
+  font-size: 13.5px;
+  line-height: 1.65;
+}
+.v6-md p:last-child { margin-bottom: 0; }
+.v6-md strong { color: var(--ink); font-weight: 500; }
+.v6-md em { color: var(--accent); font-style: italic; }
+.v6-md ul { margin: 4px 0 14px; padding-left: 0; list-style: none; }
+.v6-md li {
+  padding: 4px 0 4px 22px;
   position: relative;
-  transition: transform 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
-  box-shadow: var(--personal-card-shadow);
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.6;
 }
+.v6-md li::before { content: "▸"; position: absolute; left: 0; color: var(--accent); }
 
-.home-card:hover {
-  transform: translateY(-2px);
-  border-color: var(--personal-card-border-hover);
-  box-shadow: var(--personal-shadow-hover);
+.v6-input-wrap {
+  border-top: 1px solid var(--rule-mid);
+  padding: 14px 20px 16px;
+  background: var(--paper-in);
 }
+.v6-quick {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+.v6-quick-chip {
+  padding: 4px 10px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 16px;
+  font-size: 11px;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.12s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.v6-quick-chip:hover { background: var(--accent); color: var(--paper); }
+.v6-quick-chip .cmd { opacity: 0.7; font-weight: 500; }
 
-.home-card-kind {
+.v6-input-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: rgba(245, 244, 238, 0.04);
+  border: 1px solid var(--rule-dashed);
+  border-radius: 8px;
+  transition: border-color 0.15s;
+}
+.v6-input-row:focus-within {
+  border-color: rgba(217, 119, 87, 0.5);
+  background: rgba(245, 244, 238, 0.06);
+}
+.v6-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 13.5px;
+  padding: 4px 0;
+}
+.v6-input::placeholder { color: var(--ink-5); }
+.v6-send {
+  background: var(--accent);
+  color: var(--paper);
+  border: none;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  font-weight: 500;
+}
+.v6-send:hover { background: var(--accent-hi); }
+.v6-send:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.v6-statusbar {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--ink-5);
+  border-top: 1px solid var(--rule-soft);
+  background: var(--paper-low);
+}
+.v6-statusbar-l, .v6-statusbar-r { display: flex; gap: 14px; }
+.v6-statusbar b { color: var(--ink-3); font-weight: 400; }
+
+.v6-below {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+  margin-top: 18px;
+}
+.v6-below-card {
+  background: var(--paper-2);
+  border: 1px solid var(--rule-mid);
+  border-radius: 10px;
+  padding: 16px 18px;
+  text-decoration: none;
+  display: block;
+  color: inherit;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.v6-below-card:hover {
+  border-color: var(--accent-line-2);
+  transform: translateY(-1px);
+  color: inherit;
+}
+.v6-below-label {
+  font-size: 10px;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  font: 700 0.67rem "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--personal-accent);
-  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+.v6-below-title {
+  font-family: var(--serif);
+  font-size: 22px;
+  color: var(--ink);
+  margin: 0 0 8px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+.v6-below-body {
+  color: var(--ink-3);
+  font-size: 12.5px;
+  line-height: 1.55;
   margin: 0;
 }
+.v6-below-card .stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 16px;
+  font-size: 12px;
+  margin-top: 12px;
+}
+.v6-below-card .stats b { color: var(--ink); font-weight: 500; }
+.v6-below-card .stats span { color: var(--ink-5); }
 
-.home-card h3 {
-  margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.35;
+.v6-legend {
+  margin-top: 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  font-size: 11px;
+  color: var(--ink-5);
+  border-top: 1px dashed var(--rule);
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.home-card h3 a {
-  color: var(--personal-text);
+.v6-post-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 4px 0 14px;
+}
+.v6-post-row {
+  display: grid;
+  grid-template-columns: 100px 1fr 160px;
+  gap: 16px;
+  padding: 10px 14px;
+  background: var(--paper-2);
+  font-size: 12.5px;
+  color: var(--ink-2);
+  text-decoration: none;
+  transition: background 0.12s;
+}
+.v6-post-row:hover { background: #30302d; color: var(--ink-2); }
+.v6-post-row .d { color: var(--ink-5); font-size: 11px; }
+.v6-post-row .t { color: var(--ink); }
+.v6-post-row .g { color: var(--ink-3); font-size: 11px; text-align: right; }
+
+/* -----------------------------------------------------------------------
+   Writing list — $ tail -f posts/
+   ----------------------------------------------------------------------- */
+.v6-subhead {
+  max-width: var(--shell-max);
+  margin: 0 auto;
+  padding: 10px 24px 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-4);
+}
+.v6-subhead a { color: var(--accent); text-decoration: none; }
+.v6-subhead .sep { margin: 0 10px; color: var(--ink-6); }
+
+.v6-tool-line {
+  color: var(--accent);
+  font-weight: 500;
+  margin-bottom: 6px;
+  font-family: var(--mono);
+}
+.v6-tool-line span.out { color: var(--ink); font-weight: 500; }
+
+.v6-filters {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed var(--rule);
+  align-items: center;
+}
+.v6-filters-label {
+  font-size: 11px;
+  color: var(--ink-5);
+  margin-right: 6px;
+  padding: 4px 0;
+}
+.v6-filter {
+  padding: 3px 10px;
+  border-radius: 14px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid var(--accent-line);
+  font-size: 11px;
   text-decoration: none;
 }
+.v6-filter:hover { background: var(--accent); color: var(--paper); }
+.v6-filter.active { background: var(--accent); color: var(--paper); }
 
-.home-card h3 a:hover {
-  color: var(--personal-accent);
+details.v6-stream-item {
+  border-left: 2px solid var(--rule);
+  padding-left: 16px;
+  margin-bottom: 14px;
+  transition: border-color 0.15s;
 }
-
-.home-card p {
-  margin: 0;
-  color: var(--personal-muted);
-  line-height: 1.55;
+details.v6-stream-item[open] { border-color: var(--accent); }
+.v6-stream-summary {
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: auto 110px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  list-style: none;
+  padding: 4px 0;
 }
+.v6-stream-summary::-webkit-details-marker { display: none; }
+.v6-stream-caret { color: var(--accent); font-size: 11px; }
+.v6-stream-date { color: var(--ink-5); font-size: 11px; }
+.v6-stream-title { color: var(--ink); font-size: 14px; font-weight: 500; }
+.v6-stream-meta { color: var(--ink-4); font-size: 11px; text-align: right; }
+details.v6-stream-item[open] .v6-stream-caret::before { content: "▾"; }
+details.v6-stream-item:not([open]) .v6-stream-caret::before { content: "▸"; }
 
-.home-meta {
-  margin-top: auto;
-  color: var(--personal-meta);
-  font-size: 0.84rem;
+.v6-stream-body { margin-top: 10px; padding-left: 24px; }
+.v6-stream-fm {
+  background: rgba(245, 244, 238, 0.03);
+  border: 1px solid var(--rule-mid);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  color: var(--ink-4);
+  font-size: 11.5px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  font-family: var(--mono);
 }
-
-.home-meta-list {
+.v6-stream-sum {
+  color: var(--ink-2);
+  font-size: 13px;
+  margin: 8px 0 10px;
+  line-height: 1.6;
+  max-width: 700px;
+}
+.v6-stream-links {
   display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: 11px;
+}
+.v6-stream-links a { color: var(--accent); text-decoration: none; }
+.v6-stream-links a.secondary { color: var(--ink-4); }
+.v6-stream-links .sep { color: var(--ink-5); }
+
+.v6-stream-end {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--rule);
+  font-size: 11px;
+  color: var(--ink-5);
+  display: flex;
+  justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 10px;
 }
 
-.home-meta-list span {
-  border-radius: 999px;
-  padding: 0.22rem 0.52rem;
-  border: 1px solid var(--personal-meta-list-border);
-  color: var(--personal-meta-list-text);
-  font-size: 0.74rem;
+/* -----------------------------------------------------------------------
+   Post detail — $ read_file
+   ----------------------------------------------------------------------- */
+.v6-fm-card {
+  margin: 0 24px 18px;
+  padding: 14px 16px;
+  background: var(--accent-soft-2);
+  border: 1px solid rgba(217, 119, 87, 0.18);
+  border-radius: 8px;
+}
+.v6-section-label {
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.v6-fm-pre {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  font-family: var(--mono);
+}
+.v6-fm-pre .k { color: var(--ink-4); }
+
+.v6-post-head {
+  padding: 0 24px 20px;
+  border-bottom: 1px dashed var(--rule);
+}
+.v6-post-head h1 {
+  font-family: var(--serif);
+  font-size: 48px;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 6px 0 14px;
+  color: var(--ink);
+  font-weight: 400;
+}
+.v6-post-head h1 em { color: var(--accent); font-style: italic; }
+.v6-post-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: var(--ink-4);
+  letter-spacing: 0.04em;
+  flex-wrap: wrap;
+}
+.v6-post-meta em { color: var(--accent); font-style: normal; }
+
+.v6-post-body {
+  padding: 18px 24px;
+  color: var(--ink-2);
+  font-size: 14.5px;
+  line-height: 1.7;
+  font-family: var(--sans);
+}
+.v6-post-body h1, .v6-post-body h2, .v6-post-body h3, .v6-post-body h4 {
+  font-family: var(--serif);
+  color: var(--ink);
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  line-height: 1.15;
+  margin: 28px 0 10px;
+}
+.v6-post-body h2 { font-size: 28px; color: var(--ink); }
+.v6-post-body h3 { font-size: 22px; color: var(--accent); }
+.v6-post-body h4 { font-size: 18px; }
+.v6-post-body p { margin: 0 0 14px; }
+.v6-post-body strong { color: var(--ink); font-weight: 500; }
+.v6-post-body em { color: var(--accent); font-style: italic; }
+.v6-post-body a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+.v6-post-body a:hover { color: var(--accent-hi); }
+.v6-post-body ul, .v6-post-body ol { padding-left: 0; list-style: none; }
+.v6-post-body ul li, .v6-post-body ol li {
+  padding-left: 22px;
+  position: relative;
+  margin: 4px 0;
+}
+.v6-post-body ul li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+.v6-post-body ol { counter-reset: v6-ol; }
+.v6-post-body ol li { counter-increment: v6-ol; }
+.v6-post-body ol li::before {
+  content: counter(v6-ol) ".";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.v6-post-body blockquote {
+  border-left: 3px solid var(--accent);
+  padding-left: 14px;
+  margin: 14px 0;
+  color: var(--ink-2);
+  font-family: var(--serif);
+  font-size: 18px;
+  font-style: italic;
+  line-height: 1.45;
+}
+.v6-post-body pre {
+  background: rgba(245, 244, 238, 0.04);
+  border: 1px solid var(--rule-mid);
+  border-radius: 8px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--ok);
+  line-height: 1.6;
+}
+.v6-post-body code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  background: rgba(245, 244, 238, 0.06);
+  color: var(--accent);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.v6-post-body pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+.v6-post-body hr {
+  border: 0;
+  border-top: 1px dashed var(--rule);
+  margin: 22px 0;
+}
+.v6-post-body img {
+  max-width: 100%;
+  border-radius: 6px;
+  border: 1px solid var(--rule-mid);
+}
+.v6-post-body table {
+  width: 100%;
+  font-size: 13px;
+  border-collapse: collapse;
+  margin: 14px 0;
+}
+.v6-post-body th, .v6-post-body td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--rule-mid);
+  text-align: left;
+}
+.v6-post-body th { color: var(--ink); font-weight: 500; }
+
+.v6-ask {
+  margin: 24px;
+  padding: 16px 18px;
+  background: var(--accent-soft-2);
+  border: 1px solid var(--accent-line);
+  border-radius: 10px;
+}
+.v6-ask-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 12px;
+  background: rgba(245, 244, 238, 0.04);
+  border: 1px solid var(--rule-dashed);
+  border-radius: 8px;
+}
+.v6-ask-row input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.v6-ask-row input::placeholder { color: var(--ink-5); }
+.v6-ask-row button {
+  background: var(--accent);
+  color: var(--paper);
+  border: none;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.v6-post-nav {
+  padding: 14px 24px;
+  border-top: 1px dashed var(--rule);
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  gap: 16px;
+}
+.v6-post-nav a { color: var(--ink-4); text-decoration: none; }
+.v6-post-nav a .nv-label {
+  font-size: 10px;
+  color: var(--ink-5);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.v6-post-nav a .nv-title { color: var(--ink); display: block; }
+.v6-post-nav a.next { text-align: right; }
+
+/* -----------------------------------------------------------------------
+   Projects — $ cat projects.json
+   ----------------------------------------------------------------------- */
+.v6-proj-intro {
+  margin: 14px 0 18px;
+  color: var(--ink-4);
+  font-size: 13px;
+}
+.v6-proj-intro em { color: var(--accent); font-style: normal; }
+.v6-proj-intro .caret { color: var(--accent); }
+
+.v6-proj-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.v6-proj-card {
+  background: rgba(245, 244, 238, 0.02);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  padding: 16px 18px;
+  position: relative;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+}
+.v6-proj-card.featured { box-shadow: 0 0 0 1px var(--accent-line-2); }
+.v6-proj-card .flag {
+  position: absolute;
+  top: -1px;
+  right: 12px;
+  background: var(--accent);
+  color: var(--paper);
+  font-size: 9px;
+  padding: 2px 8px;
+  border-radius: 0 0 4px 4px;
+  letter-spacing: 0.1em;
   font-weight: 600;
 }
-
-.home-meta-wrap {
-  margin-top: auto;
-  display: grid;
-  gap: 0.55rem;
-}
-
-.home-about .home-about-content {
-  margin: 0;
-}
-
-.home-about-cta {
-  margin-top: 0.9rem;
+.v6-proj-head-row {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.home-link-inline {
-  width: fit-content;
-  color: var(--personal-link);
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.home-link-inline:hover {
-  text-decoration: underline;
-}
-
-.home-contact-wrap {
-  display: flex;
-  flex-wrap: wrap;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.55rem;
+  margin-bottom: 10px;
+  font-size: 11px;
+  color: var(--ink-5);
 }
+.v6-proj-status { text-transform: uppercase; letter-spacing: 0.1em; font-size: 10px; }
+.v6-proj-status.shipped { color: var(--ok); }
+.v6-proj-status.private { color: var(--ink-5); }
+.v6-proj-status.archived { color: var(--warn); }
+.v6-proj-title {
+  font-family: var(--serif);
+  font-size: 26px;
+  color: var(--ink);
+  letter-spacing: -0.015em;
+  margin: 0 0 4px;
+  font-weight: 400;
+  line-height: 1.1;
+}
+.v6-proj-slug {
+  font-size: 11px;
+  color: var(--accent);
+  margin-bottom: 12px;
+  font-family: var(--mono);
+}
+.v6-proj-desc {
+  color: var(--ink-3);
+  font-size: 12.5px;
+  line-height: 1.55;
+  margin: 0 0 14px;
+}
+.v6-proj-stack-wrap {
+  padding: 10px 0;
+  border-top: 1px dashed var(--rule-mid);
+  font-size: 11px;
+  color: var(--ink-4);
+}
+.v6-proj-stack-label {
+  margin-bottom: 6px;
+  color: var(--ink-5);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.v6-proj-stack { display: flex; gap: 5px; flex-wrap: wrap; }
+.v6-proj-stack span {
+  padding: 2px 8px;
+  background: rgba(245, 244, 238, 0.05);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  color: var(--ink-2);
+  font-size: 11px;
+}
+.v6-proj-links {
+  margin-top: 12px;
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+}
+.v6-proj-links a { color: var(--accent); text-decoration: none; }
+.v6-proj-links a.secondary { color: var(--ink-4); }
+.v6-proj-links .sep { color: var(--ink-5); }
 
-.home-empty {
+.v6-buildlog {
+  margin-top: 20px;
+  padding: 14px 16px;
+  background: rgba(245, 244, 238, 0.02);
+  border: 1px solid var(--rule-mid);
+  border-radius: 8px;
+}
+.v6-buildlog-row {
+  display: grid;
+  grid-template-columns: 150px auto 1fr;
+  gap: 12px;
+  padding: 3px 0;
+  font-size: 11.5px;
+  color: var(--ink-3);
+}
+.v6-buildlog-row .t { color: var(--ink-5); }
+.v6-buildlog-row .ok { color: var(--ok); }
+
+/* -----------------------------------------------------------------------
+   About — ~/.config/leonardo.toml
+   ----------------------------------------------------------------------- */
+.v6-about-intro {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 28px;
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px dashed var(--rule);
+}
+.v6-portrait {
+  aspect-ratio: 1 / 1;
+  background:
+    repeating-linear-gradient(135deg, transparent 0, transparent 14px,
+      rgba(217,119,87,0.08) 14px, rgba(217,119,87,0.08) 15px),
+    rgba(245, 244, 238, 0.04);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+.v6-portrait-monogram {
+  font-family: var(--serif);
+  font-size: 36px;
+  color: var(--accent);
+  font-style: italic;
+}
+.v6-portrait-label {
+  font-size: 10px;
+  color: var(--ink-5);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-top: 6px;
+}
+.v6-about-headline {
+  font-family: var(--serif);
+  font-size: 48px;
+  color: var(--ink);
+  margin: 0 0 10px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+.v6-about-headline em { color: var(--accent); font-style: italic; }
+.v6-about-lead {
+  color: var(--ink-2);
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0 0 14px;
+  max-width: 560px;
+}
+.v6-about-lead b { color: var(--ink); font-weight: 500; }
+.v6-about-sub {
+  color: var(--ink-3);
+  font-size: 13.5px;
+  line-height: 1.65;
   margin: 0;
-  color: var(--personal-muted);
+  max-width: 580px;
 }
 
-@media (max-width: 700px) {
-  .home-section-head {
-    flex-wrap: wrap;
-  }
+.v6-toml-block { margin-bottom: 20px; }
+.v6-toml-head {
+  color: var(--accent);
+  font-size: 13px;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-family: var(--mono);
+}
+.v6-toml-rows {
+  padding-left: 16px;
+  border-left: 1px solid var(--rule-mid);
+}
+.v6-toml-row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 16px;
+  padding: 3px 0;
+  font-size: 13px;
+  font-family: var(--mono);
+}
+.v6-toml-row .k { color: var(--ink-4); }
+.v6-toml-row .v { color: var(--ink-2); }
+.v6-toml-row .v em { color: var(--ok); font-style: normal; }
 
-  .home-cta-row,
-  .home-contact-wrap {
-    justify-content: flex-start;
-  }
+.v6-connect {
+  margin-top: 8px;
+  padding: 16px 18px;
+  background: var(--accent-soft-2);
+  border: 1px solid var(--accent-line);
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 20px;
+  align-items: center;
+}
+.v6-connect-body {
+  color: var(--ink-2);
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+.v6-connect-links {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+.v6-connect-links a { color: var(--accent); text-decoration: none; }
 
-  .home-focus-grid {
-    grid-template-columns: 1fr;
-  }
+/* -----------------------------------------------------------------------
+   Resume — $ git log --oneline
+   ----------------------------------------------------------------------- */
+.v6-resume-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  padding-bottom: 18px;
+  border-bottom: 1px dashed var(--rule);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.v6-resume-head h1 {
+  font-family: var(--serif);
+  font-size: 44px;
+  color: var(--ink);
+  margin: 0 0 6px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+}
+.v6-resume-head h1 em { color: var(--ink-4); font-style: italic; }
+.v6-resume-sub { color: var(--ink-3); font-size: 13px; }
+.v6-resume-sub em { color: var(--accent); font-style: normal; }
+.v6-dl-btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 8px 14px;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  text-decoration: none;
+  border-radius: 6px;
+  letter-spacing: 0.06em;
+  align-self: flex-start;
+}
+.v6-dl-btn:hover { background: var(--accent); color: var(--paper); }
 
-  .home-about-cta .home-btn {
-    padding: 0.52rem 0.9rem;
-    font-size: 0.91rem;
-  }
+.v6-gitlog {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.9;
+  margin-top: 14px;
+  background: rgba(245, 244, 238, 0.02);
+  border: 1px solid var(--rule-mid);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.v6-gitlog-row {
+  display: grid;
+  grid-template-columns: 20px 80px 100px 70px 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 2px 0;
+}
+.v6-gitlog-row .dot { font-size: 14px; }
+.v6-gitlog-row .hash { color: var(--accent); font-weight: 500; }
+.v6-gitlog-row .date { color: var(--ink-5); }
+.v6-gitlog-row .kind {
+  font-size: 10px;
+  padding: 1px 6px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  text-align: center;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.v6-gitlog-row .kind.feat { color: var(--ok); }
+.v6-gitlog-row .kind.perf { color: var(--warn); }
+.v6-gitlog-row .kind.merge { color: var(--accent); }
+.v6-gitlog-row .kind.init { color: var(--ink-4); }
+.v6-gitlog-row .msg { color: var(--ink-2); }
+.v6-gitlog-row .tag { margin-left: 8px; font-size: 11px; }
 
-  .header {
-    padding: 0 0 0.25rem;
-  }
+.v6-cv {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 32px;
+  margin-top: 28px;
+}
+.v6-cv aside .v6-toml-block { margin-bottom: 22px; }
+.v6-cv aside .v6-toml-row { grid-template-columns: 70px 1fr; font-size: 12px; }
+.v6-cv aside .v6-toml-row .v em { color: var(--ink-2); }
+.v6-cv-section { margin-bottom: 26px; }
+.v6-cv-section h2 {
+  color: var(--accent);
+  font-size: 12px;
+  margin: 0 0 12px;
+  font-weight: 500;
+  font-family: var(--mono);
+}
+.v6-cv-p {
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 680px;
+}
+.v6-cv-entry {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 16px;
+  padding: 10px 0;
+  border-top: 1px dashed var(--rule-mid);
+}
+.v6-cv-entry:first-of-type { border-top: none; }
+.v6-cv-when { color: var(--ink-5); font-size: 11px; }
+.v6-cv-inst {
+  font-family: var(--serif);
+  font-size: 20px;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.v6-cv-role { color: var(--ink-3); font-size: 13px; margin-top: 2px; }
+.v6-cv-role.italic { color: var(--accent); font-style: italic; font-size: 12.5px; }
+.v6-cv-notes {
+  margin: 8px 0 0;
+  padding-left: 0;
+  list-style: none;
+  font-size: 12.5px;
+  color: var(--ink-4);
+}
+.v6-cv-notes li {
+  padding-left: 16px;
+  position: relative;
+}
+.v6-cv-notes li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+.v6-skills-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 16px;
+  padding: 8px 0;
+  border-top: 1px dashed var(--rule-mid);
+}
+.v6-skills-row:first-of-type { border-top: none; }
+.v6-skills-row .k { color: var(--ink-4); font-size: 11px; padding-top: 4px; }
+.v6-skills-row .chips { display: flex; gap: 5px; flex-wrap: wrap; }
+.v6-skills-row .chips span {
+  padding: 3px 9px;
+  background: rgba(245, 244, 238, 0.05);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  color: var(--ink-2);
+  font-size: 11px;
+}
 
-  .nav {
-    width: min(1080px, 92vw);
-    display: grid;
-    gap: 0.35rem;
-  }
+/* -----------------------------------------------------------------------
+   Footer
+   ----------------------------------------------------------------------- */
+footer.footer {
+  background: transparent !important;
+  color: var(--ink-5) !important;
+  font-family: var(--mono) !important;
+  font-size: 11px !important;
+  padding: 20px 24px 28px !important;
+  max-width: var(--shell-max) !important;
+  margin: 0 auto !important;
+  border-top: 1px dashed var(--rule) !important;
+}
+footer.footer span { color: var(--ink-5) !important; }
+footer.footer a { color: var(--accent) !important; }
 
-  .logo,
-  #menu,
-  .logo-switches {
-    margin-inline: 0;
-  }
+/* -----------------------------------------------------------------------
+   Fallback list/single pages — minimal V6 reskin
+   ----------------------------------------------------------------------- */
+.page-header, .post-header {
+  max-width: var(--shell-max);
+  margin: 20px auto 0;
+  padding: 0 24px;
+}
+.page-header h1, .post-header h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  color: var(--ink);
+  letter-spacing: -0.015em;
+}
+.breadcrumbs, .breadcrumbs a {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  text-transform: lowercase;
+}
+.breadcrumbs a:hover { color: var(--accent); }
 
-  #menu {
-    overflow-x: unset;
-    white-space: normal;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    width: 100%;
-  }
+.post-entry, .first-entry, .tag-entry {
+  background: var(--paper-2) !important;
+  border: 1px solid var(--rule) !important;
+  border-radius: 10px !important;
+  padding: 16px 20px !important;
+  margin-bottom: 12px !important;
+}
+.post-entry:hover, .first-entry:hover, .tag-entry:hover {
+  border-color: var(--accent-line-2) !important;
+}
+.entry-header h2, .first-entry .entry-header h2 {
+  font-family: var(--serif) !important;
+  font-weight: 400 !important;
+  color: var(--ink) !important;
+  letter-spacing: -0.01em;
+}
+.entry-content p { color: var(--ink-3) !important; font-size: 13px; }
+.entry-footer, .post-meta { color: var(--ink-5) !important; font-size: 11px !important; }
 
-  #menu li + li {
-    margin-inline-start: 0;
-  }
+.pagination .prev, .pagination .next {
+  background: var(--paper-2) !important;
+  color: var(--accent) !important;
+  border: 1px solid var(--accent-line) !important;
+  font-family: var(--mono) !important;
+  font-size: 11px !important;
+  border-radius: 6px !important;
+}
 
-  #menu a span {
-    padding: 0.25rem 0.65rem;
-    font-size: 0.9rem;
-  }
+/* -----------------------------------------------------------------------
+   Responsive
+   ----------------------------------------------------------------------- */
+@media (max-width: 900px) {
+  .v6-topbar { flex-wrap: wrap; gap: 12px; }
+  .v6-topnav { order: 3; width: 100%; justify-content: flex-start; flex-wrap: wrap; }
+  .v6-panel-top-r { display: none; }
+  .v6-below { grid-template-columns: 1fr; }
+  .v6-proj-grid { grid-template-columns: 1fr; }
+  .v6-about-intro { grid-template-columns: 1fr; }
+  .v6-portrait { max-width: 200px; }
+  .v6-cv { grid-template-columns: 1fr; }
+  .v6-post-head h1, .v6-about-headline { font-size: 36px; }
+  .v6-resume-head h1 { font-size: 34px; }
+  .v6-stream-summary { grid-template-columns: auto 90px 1fr; }
+  .v6-stream-meta { display: none; }
+  .v6-gitlog-row { grid-template-columns: 16px 70px 80px 60px 1fr; font-size: 11.5px; }
+  .v6-cv-entry { grid-template-columns: 1fr; }
+  .v6-legend span:last-child { display: none; }
+  .v6-post-row { grid-template-columns: 80px 1fr; }
+  .v6-post-row .g { display: none; }
+  .v6-connect { grid-template-columns: 1fr; }
+}
 
-  .logo-switches {
-    margin-left: auto;
-  }
-
-  .home-section-nav {
-    margin-top: 1rem;
-    gap: 0.45rem;
-  }
-
-  .home-section-nav-link {
-    font-size: 0.75rem;
-    padding: 0.37rem 0.65rem;
-  }
+@media (max-width: 600px) {
+  .v6-shell { padding: 16px 16px 24px; }
+  .v6-convo { padding: 18px 16px 20px; }
+  .v6-welcome-title { font-size: 22px; }
+  .v6-post-head h1, .v6-about-headline { font-size: 30px; }
+  .v6-statusbar { flex-direction: column; gap: 4px; }
+  .v6-panel-top-l span { display: none; }
 }

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,5 +1,4 @@
 ---
 title: "Projects"
-layout: "archives"
 summary: "showcase of my work"
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,8 +7,8 @@ theme = "PaperMod"
   author = "Leonardo Foo Haw Yang"
   description = "Leonardo Foo's personal blog about AI engineering, machine learning, and software development."
   keywords = ["AI", "machine learning", "software engineering", "Hugo", "Python"]
-  defaultTheme = "auto"
-  disableThemeToggle = false
+  defaultTheme = "dark"
+  disableThemeToggle = true
 
   [params.profileMode]
     enabled = false
@@ -60,6 +60,8 @@ theme = "PaperMod"
   weight = 4
 
   [params.home]
+    brandSub = "胡皓雍 · taipei"
+    nowTitle = "NTUAIS, cohort 02"
     kicker = "AI. Build. Explain."
     title = "Hi, I'm Leonardo Foo"
     subtitle = "Software developer, AI researcher, and organizer of NTUAIS."

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,25 +6,6 @@
 {{- with $home.featuredPostCount }}{{ $postLimit = . }}{{ end }}
 {{- $projectLimit := 3 }}
 {{- with $home.featuredProjectCount }}{{ $projectLimit = . }}{{ end }}
-{{- $postsPage := site.GetPage "/posts" }}
-{{- $projectsPage := site.GetPage "/projects" }}
-{{- $aboutPage := site.GetPage "/about" }}
-{{- $resumePage := site.GetPage "/resume" }}
-{{- $identityDefaults := slice
-"Software Developer"
-"AI Researcher"
-"NTUAIS Organizer"
-"Product-minded Builder"
-}}
-{{- $identityList := $home.identities | default $identityDefaults }}
-{{- $focusDefaults := slice
-"AI safety research and applied systems"
-"Responsible deployment practices"
-"Community building for NTUAIS"
-"Rapid AI tooling and prototyping"
-}}
-{{- $focusList := $home.focuses | default $focusDefaults }}
-{{- $nowLine := $home.now | default "Currently building practical AI tools, writing about safety-by-design systems, and strengthening the AI ethics ecosystem in Taiwan." }}
 
 {{- $allPosts := where site.RegularPages "Section" "posts" }}
 {{- $allPosts = where $allPosts "Params.hiddenInHomeList" "!=" "true" }}
@@ -41,130 +22,142 @@
 {{- $featuredProjects = first $projectLimit (sort $allProjects "Date" "desc") }}
 {{- end }}
 
-<section class="home-wrap">
-  <section class="home-hero" aria-label="Introduction">
-    <p class="home-kicker">{{ $home.kicker | default "AI + Systems + Product" }}</p>
-    <h1 class="home-title">{{ $home.title | default site.Title }}</h1>
-    <p class="home-subtitle">{{ $home.subtitle | default site.Params.description }}</p>
-    <p class="home-intro">{{ $home.intro | default "Recent thoughts, projects, and short technical reflections." }}</p>
-    <div class="home-identity-wrap" role="list" aria-label="Current roles">
-      {{- range $identityList }}
-      <span class="home-identity" role="listitem">{{ . }}</span>
-      {{- end }}
-    </div>
-    <div class="home-cta-row">
-      {{- range $home.ctas }}
-      {{- $style := .style | default "secondary" }}
-      {{- if findRE "^#" .url }}
-      <a class="home-btn home-btn-{{ $style }}" href="{{ .url }}">{{ .name }}</a>
-      {{- else if findRE "://" .url }}
-      <a class="home-btn home-btn-{{ $style }}" href="{{ .url }}">{{ .name }}</a>
-      {{- else }}
-      <a class="home-btn home-btn-{{ $style }}" href="{{ strings.TrimPrefix .url "/" | absURL }}">{{ .name }}</a>
-      {{- end }}
-      {{- end }}
-    </div>
-    <div class="home-now">
-      <p class="home-now-label">Now</p>
-      <p>{{ $nowLine }}</p>
-    </div>
-    <div class="home-focus-grid" role="list" aria-label="Focus list">
-      {{- range $focusList }}
-      <p class="home-focus-item" role="listitem">{{ . }}</p>
-      {{- end }}
-    </div>
-    {{- with $home.skills }}
-    <p class="home-skill-title">Focus areas</p>
-    <div class="home-skill-wrap" role="list" aria-label="Focus areas">
-      {{- range . }}
-      <span class="home-skill" role="listitem">{{ . }}</span>
-      {{- end }}
-    </div>
-    {{- end }}
+{{- $latestPost := index (first 1 (sort $allPosts "Date" "desc")) 0 }}
+{{- $featProject := index (first 1 (sort $allProjects "Date" "desc")) 0 }}
+{{- with (sort (where $allProjects "Params.featured" true) "Date" "desc") }}
+{{- $featProject = index . 0 }}
+{{- end }}
 
-    <div class="home-section-nav" role="list" aria-label="Page sections">
-      <a class="home-section-nav-link" href="#featured-posts" role="listitem">Featured articles</a>
-      <a class="home-section-nav-link" href="#about-section" role="listitem">About</a>
-      <a class="home-section-nav-link" href="#projects-section" role="listitem">Projects</a>
-      <a class="home-section-nav-link" href="#contact-section" role="listitem">Contact</a>
-    </div>
-  </section>
+<section class="v6-shell">
 
-  <section class="home-section" id="featured-posts" aria-labelledby="featured-posts-title">
-    <div class="home-section-head">
-      <h2 id="featured-posts-title">Featured articles</h2>
-      <a class="home-link" href="{{ with $postsPage }}{{ .RelPermalink }}{{ else }}{{ "/posts/" | absURL }}{{ end }}">View all posts</a>
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>session · ask-leonardo</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>model: claude-sonnet-4.5</span>
+        <span>context: 12.4k / 200k</span>
+        <span>cwd: ~/leonardo</span>
+      </div>
     </div>
-    <div class="home-grid">
-      {{- range $post := $featuredPosts }}
-      <article class="home-card">
-        <p class="home-card-kind">Article</p>
-        <h3><a href="{{ $post.RelPermalink }}">{{ $post.Title }}</a></h3>
-        <p>{{ $post.Summary | plainify | truncate 140 }}</p>
-        <p class="home-meta">{{ $post.Date.Format "Jan 2, 2006" }} · {{ $post.ReadingTime }} min read</p>
-        <a class="home-link-inline" href="{{ $post.RelPermalink }}">Read</a>
-      </article>
-      {{- else }}
-      <p class="home-empty">No posts yet. Start writing in <code>content/posts</code>.</p>
-      {{- end }}
-    </div>
-  </section>
 
-  {{- with site.GetPage "/about" }}
-  <section class="home-about home-section" id="about-section" aria-labelledby="about-section-title">
-    <div class="home-section-head">
-      <h2 id="about-section-title">{{ $home.aboutTitle | default .Title }}</h2>
-      <a class="home-link" href="{{ with $aboutPage }}{{ .RelPermalink }}{{ else }}{{ "/about/" | absURL }}{{ end }}">Read more</a>
-    </div>
-    <p class="home-about-content">{{ $home.aboutBlurb | default .Summary }}</p>
-    <div class="home-about-cta">
-      <a class="home-btn home-btn-secondary" href="{{ with $aboutPage }}{{ .RelPermalink }}{{ else }}{{ "/about/" | absURL }}{{ end }}">About me</a>
-      <a class="home-btn home-btn-ghost" href="{{ with $resumePage }}{{ .RelPermalink }}{{ else }}{{ "/resume/" | absURL }}{{ end }}">Resume / CV</a>
-    </div>
-  </section>
-  {{- end }}
-
-  <section class="home-section" id="projects-section" aria-labelledby="projects-title">
-    <div class="home-section-head">
-      <h2 id="projects-title">Selected projects</h2>
-      <a class="home-link" href="{{ with $projectsPage }}{{ .RelPermalink }}{{ else }}{{ "/projects/" | absURL }}{{ end }}">Browse projects</a>
-    </div>
-    <div class="home-grid">
-      {{- range $project := $featuredProjects }}
-      <article class="home-card">
-        <p class="home-card-kind">Project</p>
-        <h3><a href="{{ $project.RelPermalink }}">{{ $project.Title }}</a></h3>
-        <p>{{ $project.Summary | plainify | truncate 160 }}</p>
-        <div class="home-meta-wrap">
-          {{- with $project.Params.technologies }}
-          <div class="home-meta-list" aria-label="Technologies">
-            {{- range . }}
-            <span>{{ . }}</span>
-            {{- end }}
-          </div>
-          {{- end }}
-          {{- if $project.Params.project_url }}
-          <a class="home-link-inline" href="{{ $project.Params.project_url }}" target="_blank" rel="noopener noreferrer">Live / repo</a>
-          {{- end }}
+    <div class="v6-convo">
+      <div class="v6-welcome">
+        <h2 class="v6-welcome-title">Hi, I'm <em>Leonardo.</em></h2>
+        <p>
+          This site runs as a small agent. Ask anything about my work in AI safety,
+          projects, writing, or NTUAIS — or use a slash command below. I'll route the
+          question and reply as myself (or close enough, via Claude).
+        </p>
+        <div class="v6-welcome-hint">
+          <span><kbd>↵</kbd> send</span>
+          <span><kbd>/</kbd> commands</span>
+          <span><kbd>tab</kbd> autocomplete</span>
+          <span><kbd>esc</kbd> clear</span>
         </div>
-      </article>
-      {{- else }}
-      <p class="home-empty">No projects yet. Add project entries under <code>content/projects</code>.</p>
-      {{- end }}
+      </div>
+
+      <div class="v6-msg">
+        <div class="v6-msg-system">leonardo-agent v2026.04 · connected · taipei</div>
+      </div>
+
+      <div class="v6-msg">
+        <div class="v6-msg-user">
+          <span class="v6-prompt">&gt;</span>
+          <span class="v6-msg-user-text">whoami</span>
+        </div>
+      </div>
+
+      <div class="v6-msg">
+        <div class="v6-msg-assistant">
+          <div class="v6-tools">
+            <div class="v6-tool"><span class="ok">✓</span><span><b>read_file</b>(<em>~/profile.md</em>)</span></div>
+            <div class="v6-tool"><span class="ok">✓</span><span><b>list_files</b>(<em>content/projects/</em>)</span></div>
+          </div>
+          <div class="v6-md">
+            <p>Hey — I'm <strong>Leonardo Foo Haw Yang</strong> (胡皓雍).</p>
+            <p>Software developer, AI researcher, and organizer of <strong>NTUAIS</strong>. M.S. student at NTU Communication Engineering, based in Taipei.</p>
+            <p>I build useful systems, explore AI safety, and share ideas that connect research, engineering, and impact.</p>
+            <ul>
+              <li>Research · model evaluation &amp; responsible deployment</li>
+              <li>Engineering · AI tooling, rapid prototyping</li>
+              <li>Community · organizing the NTU AI Safety circle</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="v6-input-wrap">
+      <div class="v6-quick">
+        <a class="v6-quick-chip" href="{{ "posts/" | absLangURL }}"><span class="cmd">/writing</span>show recent posts</a>
+        <a class="v6-quick-chip" href="{{ "projects/" | absLangURL }}"><span class="cmd">/projects</span>what have you built?</a>
+        <a class="v6-quick-chip" href="{{ "about/" | absLangURL }}"><span class="cmd">/now</span>what are you working on?</a>
+        <a class="v6-quick-chip" href="#contact"><span class="cmd">/contact</span>how do I reach you?</a>
+      </div>
+      <div class="v6-input-row">
+        <span class="v6-prompt">&gt;</span>
+        <input class="v6-input" type="text" placeholder="ask leonardo anything… (try: what got you into AI safety?)" aria-label="message input" disabled>
+        <button class="v6-send" disabled>send ↵</button>
+      </div>
+    </div>
+
+    <div class="v6-statusbar">
+      <div class="v6-statusbar-l">
+        <span><b>▸</b> agent mode</span>
+        <span>tokens/min: 1.2k</span>
+        <span>latency: 340ms</span>
+      </div>
+      <div class="v6-statusbar-r">
+        <span>utc+8</span>
+        <span>build {{ now.Format "2006.01.02" }}</span>
+        <span>hugo + claude</span>
+      </div>
+    </div>
+  </div>
+
+  <section class="v6-below" aria-label="Highlights">
+    {{- with $latestPost }}
+    <a class="v6-below-card" href="{{ .RelPermalink }}">
+      <div class="v6-below-label">▸ latest writing</div>
+      <h3 class="v6-below-title">{{ .Title }}</h3>
+      <p class="v6-below-body">{{ .Summary | plainify | truncate 140 }}</p>
+      <div class="stats">
+        <span>published</span><b>{{ .Date.Format "2006.01.02" }}</b>
+        <span>read</span><b>{{ .ReadingTime }} min</b>
+      </div>
+    </a>
+    {{- end }}
+    {{- with $featProject }}
+    <a class="v6-below-card" href="{{ .RelPermalink }}">
+      <div class="v6-below-label">▸ featured project</div>
+      <h3 class="v6-below-title">{{ .Title }}</h3>
+      <p class="v6-below-body">{{ .Summary | plainify | truncate 140 }}</p>
+      <div class="stats">
+        {{- with .Params.technologies }}
+        <span>stack</span><b>{{ delimit (first 2 .) " · " | lower }}</b>
+        {{- end }}
+        <span>status</span><b>shipped</b>
+      </div>
+    </a>
+    {{- end }}
+    <div class="v6-below-card" id="contact">
+      <div class="v6-below-label">▸ currently</div>
+      <h3 class="v6-below-title">{{ $home.nowTitle | default "NTUAIS, cohort 02" }}</h3>
+      <p class="v6-below-body">{{ $home.now | default "Running speaker sessions and student-led activities on AI safety, practical evaluation, and responsible deployment." }}</p>
+      <div class="stats">
+        <span>role</span><b>organizer</b>
+        <span>since</span><b>2024</b>
+      </div>
     </div>
   </section>
 
-  <section class="home-section" id="contact-section" aria-labelledby="contact-title">
-    <div class="home-section-head">
-      <h2 id="contact-title">{{ $home.contactTitle | default "Contact" }}</h2>
-    </div>
-    <div class="home-contact-wrap">
-      {{- range $home.contactLinks }}
-      <a class="home-btn home-btn-secondary" href="{{ .url | safeURL }}">{{ .name }}</a>
-      {{- end }}
-      <a class="home-link" href="{{ with $resumePage }}{{ .RelPermalink }}{{ else }}{{ "/resume/" | absURL }}{{ end }}">Resume / CV</a>
-    </div>
-  </section>
+  <div class="v6-legend">
+    <span>© {{ now.Year }} leonardo foo · built with hugo + claude · site runs as an agent</span>
+    <span><kbd>⌘</kbd><kbd>k</kbd> command palette · <kbd>g</kbd><kbd>p</kbd> projects · <kbd>g</kbd><kbd>w</kbd> writing</span>
+  </div>
 </section>
 
 {{- else }}

--- a/layouts/about/page.html
+++ b/layouts/about/page.html
@@ -1,0 +1,101 @@
+{{- define "main" }}
+{{- $home := site.Params.home -}}
+
+<section class="v6-shell">
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>$ cat ~/.config/leonardo.toml</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>toml · 2.1 kb</span>
+        <span>last edit: {{ .Lastmod.Format "2006-01-02" }}</span>
+        <span>readable: ✓</span>
+      </div>
+    </div>
+
+    <div style="padding: 22px 24px 24px;">
+      <div class="v6-tools">
+        <div class="v6-tool"><span class="ok">✓</span><span><b>read_file</b>(<em>~/.config/leonardo.toml</em>) → ok</span></div>
+      </div>
+
+      <div class="v6-about-intro">
+        <div class="v6-portrait" aria-hidden="true">
+          <div class="v6-portrait-monogram">LF</div>
+          <div class="v6-portrait-label">— portrait · placeholder</div>
+        </div>
+        <div>
+          <h1 class="v6-about-headline">Hi, I'm <em>Leonardo.</em></h1>
+          <p class="v6-about-lead">
+            Software developer, AI researcher, and organizer of <b>NTUAIS</b>
+            (National Taiwan University AI Safety), based in Taipei.
+          </p>
+          <p class="v6-about-sub">
+            I care about building practical AI systems and advancing responsible AI deployment —
+            and I enjoy connecting people through ideas and community work around AI safety,
+            research, and societal impact.
+          </p>
+        </div>
+      </div>
+
+      {{- $blocks := slice
+        (dict "sec" "identity" "rows" (slice
+          (slice "name" "\"Leonardo Foo Haw Yang\"")
+          (slice "zh" "\"胡皓雍\"")
+          (slice "role" "\"m.s. student · communication engineering\"")
+          (slice "affiliation" "\"national taiwan university\"")
+          (slice "org" "\"ntuais\"")
+          (slice "location" "\"taipei, tw · utc+8\"")
+        ))
+        (dict "sec" "what_i_do" "rows" (slice
+          (slice "research" "\"ai safety, practical eval, measurable impact\"")
+          (slice "engineering" "\"research ideas → deployable tools\"")
+          (slice "community" "\"organize ntuais, safety learning discussions\"")
+          (slice "writing" "\"ai engineering · safety · tech-and-society\"")
+        ))
+        (dict "sec" "off_the_clock" "rows" (slice
+          (slice "games" "[\"chess\"]")
+          (slice "anime" "[\"donghua\"]")
+          (slice "reading" "[\"ai safety\", \"chinese history\", \"geopolitics\", \"manga\", \"social science\"]")
+          (slice "workflow" "\"vibe coding · ship fast with solid iteration\"")
+          (slice "mission" "\"impact society through better ai + better engineering\"")
+        ))
+        (dict "sec" "availability" "rows" (slice
+          (slice "open_to" "[\"research collab\", \"intern\", \"speaking\"]")
+          (slice "response_time" "\"~24h\"")
+          (slice "timezone" "\"utc+8\"")
+        ))
+      }}
+      {{- range $blocks }}
+      <div class="v6-toml-block">
+        <div class="v6-toml-head">[<b>{{ .sec }}</b>]</div>
+        <div class="v6-toml-rows">
+          {{- range .rows }}
+          <div class="v6-toml-row">
+            <span class="k">{{ index . 0 }}</span>
+            <span class="v">= <em>{{ index . 1 }}</em></span>
+          </div>
+          {{- end }}
+        </div>
+      </div>
+      {{- end }}
+
+      <div class="v6-connect">
+        <div>
+          <div class="v6-section-label">▸ let's connect</div>
+          <div class="v6-connect-body">
+            Always open to meaningful conversations and collaborations around AI safety,
+            applied ML, and community work.
+          </div>
+        </div>
+        <div class="v6-connect-links">
+          {{- range $home.contactLinks }}
+          <a href="{{ .url | safeURL }}">{{ .name | lower }} ↗</a>
+          {{- end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,2 @@
+{{- /* Override PaperMod's default header with the V6 Agent top bar. */ -}}
+{{- partial "v6_topbar.html" . -}}

--- a/layouts/partials/v6_topbar.html
+++ b/layouts/partials/v6_topbar.html
@@ -1,0 +1,22 @@
+{{- /* V6 Agent-style top bar — shared across all pages. */ -}}
+{{- $page := . -}}
+{{- $path := strings.TrimPrefix "/" $page.RelPermalink -}}
+{{- $first := index (split (strings.TrimSuffix "/" $path) "/") 0 -}}
+{{- $active := cond (eq $path "") "agent" $first -}}
+{{- $home := site.Params.home -}}
+<div class="v6-topbar-wrap">
+  <header class="v6-topbar">
+    <a class="v6-brand" href="{{ "" | absLangURL }}">
+      <div class="v6-brand-glyph">L</div>
+      <div><b>leonardo.dev</b><span>— {{ $home.brandSub | default "胡皓雍 · taipei" }}</span></div>
+    </a>
+    <nav class="v6-topnav" aria-label="Primary">
+      <a href="{{ "" | absLangURL }}"{{ if eq $active "agent" }} class="active"{{ end }}>agent</a>
+      <a href="{{ "posts/" | absLangURL }}"{{ if eq $active "posts" }} class="active"{{ end }}>writing</a>
+      <a href="{{ "projects/" | absLangURL }}"{{ if eq $active "projects" }} class="active"{{ end }}>projects</a>
+      <a href="{{ "about/" | absLangURL }}"{{ if eq $active "about" }} class="active"{{ end }}>about</a>
+      <a href="{{ "resume/" | absLangURL }}"{{ if eq $active "resume" }} class="active"{{ end }}>resume</a>
+    </nav>
+    <div class="v6-status" title="open to research collab"><i></i>online · open to research collab</div>
+  </header>
+</div>

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,0 +1,79 @@
+{{- define "main" }}
+{{- $posts := sort (where .RegularPages "Params.hiddenInHomeList" "!=" "true") "Date" "desc" -}}
+{{- $count := len $posts -}}
+{{- $tags := site.Taxonomies.tags -}}
+
+<section class="v6-shell">
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>$ tail -f ~/leonardo/content/posts/</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>{{ $count }} entries</span>
+        <span>streaming: off</span>
+        <span>sort: date desc</span>
+      </div>
+    </div>
+
+    <div style="padding: 18px 24px 22px;">
+      <div style="margin-bottom:18px;">
+        <div class="v6-tool-line">
+          <span>$ </span><span class="out">glob "content/posts/*.md" | sort -r</span>
+        </div>
+        <div class="v6-tools">
+          <div class="v6-tool"><span class="ok">✓</span><span><b>glob</b>(<em>"content/posts/*.md"</em>) → {{ $count }} files</span></div>
+          <div class="v6-tool"><span class="ok">✓</span><span><b>read_frontmatter</b>(<em>--all</em>) → parsed</span></div>
+        </div>
+        <p style="color:var(--ink-3); margin: 8px 0 0; font-size: 13px;">
+          Found <strong style="color:var(--ink);">{{ $count }} posts</strong> in
+          <em style="color:var(--accent); font-style: normal;">content/posts/</em>.
+          Click any entry to preview its metadata.
+        </p>
+      </div>
+
+      {{- with $tags }}
+      <div class="v6-filters">
+        <span class="v6-filters-label">filter:</span>
+        <a class="v6-filter active" href="{{ "posts/" | absLangURL }}">all</a>
+        {{- range $name, $taxonomy := . -}}
+        {{- if ge (len $taxonomy) 1 }}
+        <a class="v6-filter" href="{{ printf "tags/%s/" ($name | urlize) | absLangURL }}">{{ $name | lower }}</a>
+        {{- end }}
+        {{- end }}
+      </div>
+      {{- end }}
+
+      {{- range $i, $p := $posts }}
+      <details class="v6-stream-item"{{ if eq $i 0 }} open{{ end }}>
+        <summary class="v6-stream-summary">
+          <span class="v6-stream-caret"></span>
+          <span class="v6-stream-date">{{ $p.Date.Format "2006-01-02" }}</span>
+          <span class="v6-stream-title">{{ $p.Title }}</span>
+          <span class="v6-stream-meta">{{ $p.ReadingTime }} min · {{ $p.WordCount }}w</span>
+        </summary>
+        {{- $tagsJson := jsonify ($p.Params.tags | default (slice)) -}}
+        {{- $lines := len (split $p.RawContent "\n") -}}
+        <div class="v6-stream-body">
+          <div class="v6-stream-fm">{{- printf "---\nfile:     %s\ndate:     %s\ntags:     %s\nread:     %d min\nlines:    %d\n---" $p.File.LogicalName ($p.Date.Format "2006-01-02") $tagsJson $p.ReadingTime $lines -}}</div>
+          <p class="v6-stream-sum">{{ $p.Summary | plainify | truncate 260 }}</p>
+          <div class="v6-stream-links">
+            <a href="{{ $p.RelPermalink }}">cat {{ $p.File.LogicalName }} →</a>
+            <span class="sep">·</span>
+            {{- with $p.OutputFormats.Get "rss" }}
+            <a class="secondary" href="{{ .RelPermalink }}">rss</a>
+            {{- end }}
+          </div>
+        </div>
+      </details>
+      {{- end }}
+
+      <div class="v6-stream-end">
+        <span>end of stream · <span style="color: var(--ok);">●</span> watching for new posts</span>
+        <span><span style="color: var(--accent);">tip:</span> press <kbd>j</kbd>/<kbd>k</kbd> to navigate</span>
+      </div>
+    </div>
+  </div>
+</section>
+{{- end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,0 +1,91 @@
+{{- define "main" }}
+{{- $all := sort (where site.RegularPages "Section" "posts") "Date" "desc" -}}
+{{- $idx := 0 -}}
+{{- $total := len $all -}}
+{{- range $i, $p := $all -}}
+  {{- if eq $p.Permalink $.Permalink -}}{{ $idx = $i }}{{- end -}}
+{{- end -}}
+{{- $prev := "" -}}
+{{- $next := "" -}}
+{{- if gt $idx 0 -}}{{ $prev = index $all (sub $idx 1) }}{{- end -}}
+{{- if lt $idx (sub $total 1) -}}{{ $next = index $all (add $idx 1) }}{{- end -}}
+
+{{- $bytes := len .RawContent -}}
+{{- $lines := len (split .RawContent "\n") -}}
+{{- $tagsJson := jsonify (.Params.tags | default (slice)) -}}
+{{- $summaryLine := .Summary | plainify | truncate 72 -}}
+
+<div class="v6-subhead">
+  <a href="{{ "posts/" | absLangURL }}">← tail -f posts/</a>
+  <span class="sep">/</span>
+  <span>post {{ printf "%02d" (add $idx 1) }} of {{ printf "%02d" $total }}</span>
+</div>
+
+<section class="v6-shell">
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>$ read_file content/posts/{{ .File.LogicalName }}</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>md · {{ $bytes }} bytes</span>
+        <span>{{ $lines }} lines</span>
+        <span>encoding: utf-8</span>
+      </div>
+    </div>
+
+    <div style="padding: 18px 0 0;">
+      <div class="v6-fm-card">
+        <div class="v6-section-label">▸ frontmatter</div>
+        <pre class="v6-fm-pre"><span class="k">title:    </span>"{{ .Title }}"
+<span class="k">date:     </span>{{ .Date.Format "2006-01-02T15:04:05-07:00" }}
+<span class="k">author:   </span>{{ .Params.author | default site.Params.author }}
+<span class="k">tags:     </span>{{ $tagsJson }}
+<span class="k">summary:  </span>"{{ $summaryLine }}"</pre>
+      </div>
+
+      <div class="v6-post-head">
+        <h1>{{ .Title }}</h1>
+        <div class="v6-post-meta">
+          <span>{{ .Date.Format "2006-01-02 · 15:04 utc+8" }}</span>
+          <span>·</span>
+          <span>{{ .ReadingTime }} min read</span>
+          {{- with .Params.tags }}
+          <span>·</span>
+          <span>tag: <em>{{ delimit . ", " }}</em></span>
+          {{- end }}
+        </div>
+      </div>
+
+      <article class="v6-post-body">
+        {{ .Content }}
+      </article>
+
+      <div class="v6-ask">
+        <div class="v6-section-label">▸ ask about this post</div>
+        <div class="v6-ask-row">
+          <span class="v6-prompt">&gt;</span>
+          <input type="text" placeholder="what theme does leonardo recommend? did he run into issues?" aria-label="question input" disabled>
+          <button type="button" disabled>ask ↵</button>
+        </div>
+      </div>
+
+      <nav class="v6-post-nav" aria-label="Post navigation">
+        {{- if $prev }}
+        <a class="prev" href="{{ $prev.RelPermalink }}">
+          <span class="nv-label">← prev</span>
+          <span class="nv-title">{{ $prev.Title }}</span>
+        </a>
+        {{- else }}<span></span>{{- end }}
+        {{- if $next }}
+        <a class="next" href="{{ $next.RelPermalink }}">
+          <span class="nv-label">next →</span>
+          <span class="nv-title">{{ $next.Title }}</span>
+        </a>
+        {{- else }}<span></span>{{- end }}
+      </nav>
+    </div>
+  </div>
+</section>
+{{- end }}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -1,0 +1,81 @@
+{{- define "main" }}
+{{- $projects := sort .RegularPages "Date" "desc" -}}
+{{- $count := len $projects -}}
+{{- $featured := where $projects "Params.featured" true -}}
+
+<section class="v6-shell">
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>$ cat ~/leonardo/projects.json | jq .</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>{{ $count }} entries</span>
+        <span>featured: {{ len $featured }}</span>
+        <span>last build: {{ now.Format "2006-01-02" }}</span>
+      </div>
+    </div>
+
+    <div style="padding: 20px 24px 22px;">
+      <div class="v6-tools">
+        <div class="v6-tool"><span class="ok">✓</span><span><b>read_file</b>(<em>~/projects.json</em>) → parsed ({{ $count }} entries)</span></div>
+        <div class="v6-tool"><span class="ok">✓</span><span><b>gh_api</b>(<em>--repos</em>) → metadata fetched</span></div>
+      </div>
+
+      <div class="v6-proj-intro">
+        <span class="caret">▸ </span>
+        Selected work across research, ML tooling, and infrastructure. Each entry is an object
+        with <em>stack</em>, <em>status</em>, and <em>description</em>.
+      </div>
+
+      <div class="v6-proj-grid">
+        {{- range $i, $p := $projects }}
+        {{- $id := printf "%03d" (add $i 1) -}}
+        {{- $status := "shipped" -}}
+        {{- with $p.Params.status }}{{ $status = . }}{{ end -}}
+        {{- $slug := $p.File.ContentBaseName -}}
+        <a class="v6-proj-card {{ if $p.Params.featured }}featured{{ end }}" href="{{ $p.RelPermalink }}">
+          {{- if $p.Params.featured }}<span class="flag">★ FEATURED</span>{{ end }}
+          <div class="v6-proj-head-row">
+            <span>prj/{{ $id }} · {{ $p.Date.Format "2006" }}</span>
+            <span class="v6-proj-status {{ $status }}">● {{ $status }}</span>
+          </div>
+          <div class="v6-proj-title">{{ $p.Title }}</div>
+          <div class="v6-proj-slug">"{{ $slug }}"</div>
+          <p class="v6-proj-desc">{{ $p.Summary | plainify | truncate 220 }}</p>
+          {{- with $p.Params.technologies }}
+          <div class="v6-proj-stack-wrap">
+            <div class="v6-proj-stack-label">stack</div>
+            <div class="v6-proj-stack">
+              {{- range . }}<span>{{ . | lower }}</span>{{ end }}
+            </div>
+          </div>
+          {{- end }}
+          <div class="v6-proj-links">
+            {{- with $p.Params.project_url }}
+            <span>gh ↗</span>
+            {{- end }}
+            <span class="sep">·</span>
+            <span class="secondary">readme</span>
+            <span class="sep">·</span>
+            <span class="secondary">ask about this</span>
+          </div>
+        </a>
+        {{- end }}
+      </div>
+
+      <div class="v6-buildlog">
+        <div class="v6-section-label">▸ recent build log</div>
+        {{- range first 4 (sort $projects "Lastmod" "desc") }}
+        <div class="v6-buildlog-row">
+          <span class="t">{{ .Lastmod.Format "2006.01.02 15:04" }}</span>
+          <span class="ok">✓</span>
+          <span>{{ .File.ContentBaseName }} · {{ .Summary | plainify | truncate 80 }}</span>
+        </div>
+        {{- end }}
+      </div>
+    </div>
+  </div>
+</section>
+{{- end }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,0 +1,80 @@
+{{- define "main" }}
+{{- $slug := .File.ContentBaseName -}}
+{{- $status := .Params.status | default "shipped" -}}
+{{- $techJson := jsonify (.Params.technologies | default (slice)) -}}
+
+<div class="v6-subhead">
+  <a href="{{ "projects/" | absLangURL }}">← cat projects.json</a>
+  <span class="sep">/</span>
+  <span>{{ $slug }}</span>
+</div>
+
+<section class="v6-shell">
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>$ read_file projects/{{ $slug }}.md</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>status: {{ $status }}</span>
+        {{- if .Params.featured }}<span>featured: true</span>{{ end }}
+        <span>updated: {{ .Lastmod.Format "2006-01-02" }}</span>
+      </div>
+    </div>
+
+    <div style="padding: 18px 0 0;">
+      <div class="v6-fm-card">
+        <div class="v6-section-label">▸ project manifest</div>
+        <pre class="v6-fm-pre"><span class="k">name:       </span>"{{ .Title }}"
+<span class="k">slug:       </span>"{{ $slug }}"
+<span class="k">year:       </span>{{ .Date.Format "2006" }}
+<span class="k">status:     </span>"{{ $status }}"
+<span class="k">featured:   </span>{{ .Params.featured | default false }}
+<span class="k">stack:      </span>{{ $techJson }}
+{{- with .Params.project_url }}
+<span class="k">url:        </span>"{{ . }}"{{ end }}</pre>
+      </div>
+
+      <div class="v6-post-head">
+        <h1>{{ .Title }}</h1>
+        <div class="v6-post-meta">
+          <span>started {{ .Date.Format "2006-01-02" }}</span>
+          <span>·</span>
+          <span>status: <em>{{ $status }}</em></span>
+          {{- with .Params.project_url }}
+          <span>·</span>
+          <span><a href="{{ . }}" target="_blank" rel="noopener noreferrer">repo ↗</a></span>
+          {{- end }}
+        </div>
+      </div>
+
+      <article class="v6-post-body">
+        {{ .Content }}
+      </article>
+
+      {{- with .Params.technologies }}
+      <div style="margin: 0 24px 20px; padding: 14px 16px; background: rgba(245,244,238,0.02); border: 1px solid var(--rule-mid); border-radius: 8px;">
+        <div class="v6-section-label">▸ stack</div>
+        <div class="v6-proj-stack">
+          {{- range . }}<span>{{ . | lower }}</span>{{ end }}
+        </div>
+      </div>
+      {{- end }}
+
+      <nav class="v6-post-nav" aria-label="Project navigation">
+        <a class="prev" href="{{ "projects/" | absLangURL }}">
+          <span class="nv-label">← back</span>
+          <span class="nv-title">All projects</span>
+        </a>
+        {{- with .Params.project_url }}
+        <a class="next" href="{{ . }}" target="_blank" rel="noopener noreferrer">
+          <span class="nv-label">open →</span>
+          <span class="nv-title">Repository</span>
+        </a>
+        {{- end }}
+      </nav>
+    </div>
+  </div>
+</section>
+{{- end }}

--- a/layouts/resume/page.html
+++ b/layouts/resume/page.html
@@ -1,0 +1,168 @@
+{{- define "main" }}
+
+<section class="v6-shell">
+  <div class="v6-panel">
+    <div class="v6-panel-top">
+      <div class="v6-panel-top-l">
+        <div class="v6-dots"><i class="r"></i><i class="y"></i><i class="g"></i></div>
+        <span>$ git log --oneline --graph --all ~/career</span>
+      </div>
+      <div class="v6-panel-top-r">
+        <span>6 commits</span>
+        <span>branch: main</span>
+        <span>branches: education · career · research · community</span>
+      </div>
+    </div>
+
+    <div style="padding: 22px 24px 26px;">
+      <div class="v6-resume-head">
+        <div>
+          <h1>Leonardo Foo <em>Haw Yang</em></h1>
+          <div class="v6-resume-sub">
+            software dev · ai researcher · ntuais organizer · <em>taipei, tw</em>
+          </div>
+        </div>
+        <a class="v6-dl-btn" href="#" aria-label="Download PDF resume">↓ download.pdf</a>
+      </div>
+
+      <div class="v6-tools">
+        <div class="v6-tool"><span class="ok">✓</span><span><b>git_log</b>(<em>--oneline --graph --all</em>) → 6 commits</span></div>
+      </div>
+
+      {{- $commits := slice
+        (dict "hash" "a7f3e21" "d" "2024" "tag" "(HEAD → main, ntuais)" "kind" "feat" "msg" "launch NTUAIS — organize student-led AI safety activities" "color" "var(--accent)")
+        (dict "hash" "3c1b88a" "d" "Sep 2024" "tag" "" "kind" "perf" "msg" "ship defect-detection CV model · 30% speedup via TensorRT" "color" "var(--ok)")
+        (dict "hash" "9e2d14f" "d" "Jul 2024" "tag" "(intern)" "kind" "feat" "msg" "start AI research internship at Tech Company Inc." "color" "var(--warn)")
+        (dict "hash" "51fa09c" "d" "Sep 2023" "tag" "(m.s.)" "kind" "feat" "msg" "begin M.S. in Communication Engineering @ NTU" "color" "var(--accent)")
+        (dict "hash" "8b4e2a7" "d" "Jun 2023" "tag" "(b.s.)" "kind" "merge" "msg" "graduate B.S. in Electrical Engineering @ NTU" "color" "var(--accent)")
+        (dict "hash" "1c0aab2" "d" "Sep 2019" "tag" "" "kind" "init" "msg" "initial commit — enroll B.S. in Electrical Engineering" "color" "var(--ink-4)")
+      }}
+      <div class="v6-gitlog">
+        {{- range $commits }}
+        {{- $dotStyle := printf "color: %s;" .color -}}
+        <div class="v6-gitlog-row">
+          <span class="dot" style="{{ $dotStyle | safeCSS }}">●</span>
+          <span class="hash">{{ .hash }}</span>
+          <span class="date">{{ .d }}</span>
+          <span class="kind {{ .kind }}">{{ .kind }}</span>
+          <span class="msg">{{ .msg }}{{ with .tag }}<span class="tag" style="{{ $dotStyle | safeCSS }}">&nbsp;{{ . }}</span>{{ end }}</span>
+        </div>
+        {{- end }}
+      </div>
+
+      <div class="v6-cv">
+        <aside>
+          <div class="v6-toml-block">
+            <div class="v6-toml-head">[<b>contact</b>]</div>
+            <div class="v6-toml-rows">
+              <div class="v6-toml-row"><span class="k">loc</span><span class="v">Taipei, TW</span></div>
+              <div class="v6-toml-row"><span class="k">email</span><span class="v">leonardo@…</span></div>
+              <div class="v6-toml-row"><span class="k">gh</span><span class="v">@leonardofhy</span></div>
+              <div class="v6-toml-row"><span class="k">li</span><span class="v">leonardo-fhy</span></div>
+            </div>
+          </div>
+          <div class="v6-toml-block">
+            <div class="v6-toml-head">[<b>languages</b>]</div>
+            <div class="v6-toml-rows">
+              <div class="v6-toml-row"><span class="k">中文</span><span class="v">native</span></div>
+              <div class="v6-toml-row"><span class="k">english</span><span class="v">fluent</span></div>
+            </div>
+          </div>
+          <div class="v6-toml-block">
+            <div class="v6-toml-head">[<b>availability</b>]</div>
+            <div class="v6-toml-rows">
+              <div class="v6-toml-row"><span class="k">open_to</span><span class="v">research / intern</span></div>
+              <div class="v6-toml-row"><span class="k">response</span><span class="v">&lt; 24h</span></div>
+              <div class="v6-toml-row"><span class="k">tz</span><span class="v">utc+8</span></div>
+            </div>
+          </div>
+        </aside>
+
+        <main>
+          <section class="v6-cv-section">
+            <h2>## summary</h2>
+            <p class="v6-cv-p">
+              Graduate student in Communication Engineering at NTU focusing on artificial intelligence
+              and machine learning, with active research interests in AI safety, system-level impact,
+              and practical deployment.
+            </p>
+          </section>
+
+          <section class="v6-cv-section">
+            <h2>## education</h2>
+            <div class="v6-cv-entry">
+              <span class="v6-cv-when">Sep 2023 — Present</span>
+              <div>
+                <div class="v6-cv-inst">National Taiwan University</div>
+                <div class="v6-cv-role">M.S. in Communication Engineering</div>
+                <ul class="v6-cv-notes">
+                  <li>focus: deep learning · computer vision</li>
+                  <li>research: ai safety · practical eval</li>
+                </ul>
+              </div>
+            </div>
+            <div class="v6-cv-entry">
+              <span class="v6-cv-when">Sep 2019 — Jun 2023</span>
+              <div>
+                <div class="v6-cv-inst">National Taiwan University</div>
+                <div class="v6-cv-role">B.S. in Electrical Engineering</div>
+              </div>
+            </div>
+          </section>
+
+          <section class="v6-cv-section">
+            <h2>## experience</h2>
+            <div class="v6-cv-entry">
+              <span class="v6-cv-when">Jul 2024 — Sep 2024</span>
+              <div>
+                <div class="v6-cv-inst">AI Research Intern</div>
+                <div class="v6-cv-role italic">Tech Company Inc.</div>
+                <ul class="v6-cv-notes">
+                  <li>computer vision models for industrial defect detection</li>
+                  <li>30% inference speedup via tensorrt</li>
+                </ul>
+              </div>
+            </div>
+            <div class="v6-cv-entry">
+              <span class="v6-cv-when">2024 — Present</span>
+              <div>
+                <div class="v6-cv-inst">Organizer</div>
+                <div class="v6-cv-role italic">NTUAIS (NTU AI Safety)</div>
+                <ul class="v6-cv-notes">
+                  <li>organize discussions, speaker sessions, student-led activities</li>
+                  <li>connect researchers + students for practical safety insights</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <section class="v6-cv-section">
+            <h2>## skills</h2>
+            {{- $skills := slice
+              (slice "languages" (slice "python" "c++" "javascript" "go"))
+              (slice "ai/ml" (slice "pytorch" "tensorflow" "opencv" "huggingface" "safe-ai-eval"))
+              (slice "web" (slice "hugo" "react" "node.js" "gh-actions"))
+              (slice "tools" (slice "docker" "git" "linux" "aws"))
+            }}
+            {{- range $skills }}
+            <div class="v6-skills-row">
+              <span class="k">{{ index . 0 }}</span>
+              <div class="chips">
+                {{- range (index . 1) }}<span>{{ . }}</span>{{ end }}
+              </div>
+            </div>
+            {{- end }}
+          </section>
+
+          {{- if .Content }}
+          <section class="v6-cv-section" style="margin-top: 32px;">
+            <h2>## from resume.md</h2>
+            <div class="v6-post-body" style="padding:0;">{{ .Content }}</div>
+          </section>
+          {{- end }}
+        </main>
+      </div>
+    </div>
+  </div>
+</section>
+{{- end }}


### PR DESCRIPTION
## Summary

Implements the V6 "Agent" direction from the [Claude Design handoff](https://api.anthropic.com/v1/design/h/gT3HU0Iz2zL42LlXb7I9KA) — the Claude Code terminal aesthetic Leonardo picked from six variations in the design chat.

- Dark-only terminal look (IBM Plex Mono + Instrument Serif, charcoal `#1f1e1d` surface, coral `#D97757` accent).
- Each page uses its own agent metaphor while sharing the V6 panel + top-bar chrome:
  - **Home** → static `ask-leonardo` REPL mock with tool-call chips, welcome card, and live highlight cards.
  - **Writing** → `$ tail -f posts/` with collapsible frontmatter per entry.
  - **Post detail** → `$ read_file` with frontmatter card, serif title, and ask-about-this-post footer.
  - **Projects** → `$ cat projects.json | jq .` with featured flag, status pills, stack chips, build log.
  - **About** → `$ cat ~/.config/leonardo.toml` with portrait placeholder and TOML-styled sections.
  - **Resume** → `$ git log --oneline` career timeline + two-column CV.

## Test plan
- [ ] `hugo --minify` completes without warnings
- [ ] `hugo server` renders home, /posts/, /posts/<slug>/, /projects/, /projects/<slug>/, /about/, /resume/
- [ ] Top-bar active state tracks the current section
- [ ] Quick-command chips on home navigate to the right sub-pages
- [ ] GitHub Pages deploy workflow picks up the merge and publishes

## Notes
- Homepage REPL is visual only — no live Claude API call (static Hugo).
- `contactLinks` still uses the `leonardo@example.com` placeholder per CLAUDE.md.
- Resume `download.pdf` is a `#` stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)